### PR TITLE
GetRealmInfo: fix new realm format (with faction)

### DIFF
--- a/TooltipRealmInfo.lua
+++ b/TooltipRealmInfo.lua
@@ -154,7 +154,7 @@ local function GetRealmInfo(object)
 
 	if #res==0 then
 		if not realm and object:find("%-") and not object:find("^Player%-") then
-			_,realm = strsplit("-",object,2); -- character name + realm
+			_,realm,_ = strsplit("- ",object,3); -- character name + realm + faction (optional)
 		end
 		if not realm then
 			realm = object;


### PR DESCRIPTION
Since 9.2.5, cross faction is enabled. Blizzard has changed the realm format.
They added an optional faction indicator at the end of the string.
It is shown only when the player is part of the opposite faction.
There is the fix.