### PR TITLE
Fix nil value

### DIFF
--- a/TooltipRealmInfo.lua
+++ b/TooltipRealmInfo.lua
@@ -197,7 +197,7 @@ local function AddLines(tt,object,_title,newLineOnFlat)
 	end
 
 	if realmInfo[iconstr] and TooltipRealmInfoDB.countryflag=="charactername" then
-		local ttName = tt:GetName();
+		local ttName = tt and tt:GetName();
 		if ttName then
 			_G[ttName.."TextLeft1"]:SetText(_G[ttName.."TextLeft1"]:GetText().." "..realmInfo[iconstr]);
 		end


### PR DESCRIPTION
TooltipRealmInfo/TooltipRealmInfo.lua:200: attempt to call method 'GetName' (a nil value)
[string "@TooltipRealmInfo/TooltipRealmInfo.lua"]:200: in function <TooltipRealmInfo/TooltipRealmInfo.lua:188>
[string "@TooltipRealmInfo/TooltipRealmInfo.lua"]:384: in function <TooltipRealmInfo/TooltipRealmInfo.lua:379>
[string "=[C]"]: in function `FriendsFrameTooltip_SetLine'
[string "@Blizzard_FriendsFrame/Mainline/FriendsFrame.lua"]:2039: in function <...dOns/Blizzard_FriendsFrame/Mainline/FriendsFrame.lua:2000>